### PR TITLE
Fix breaking changes in WTForms 3.2.1

### DIFF
--- a/frontend/app/parsnip/main/forms.py
+++ b/frontend/app/parsnip/main/forms.py
@@ -10,7 +10,7 @@ from wtforms.validators import InputRequired, Regexp, NumberRange, Optional
 # Conditional Test Classes
 ################################################################################
 class RequiredIfReferenceType(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
     
     def __init__(self, conditionalFieldName, message=None, *args, **kwargs):
         self.conditionalFieldName = conditionalFieldName
@@ -24,7 +24,7 @@ class RequiredIfReferenceType(InputRequired):
             super(RequiredIfReferenceType, self).__call__(form, field)
 
 class RequiredIfSizedElement(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
     
     def __init__(self, conditionalFieldName, message=None, *args, **kwargs):
         self.conditionalFieldName = conditionalFieldName
@@ -38,7 +38,7 @@ class RequiredIfSizedElement(InputRequired):
             super(RequiredIfSizedElement, self).__call__(form, field)
             
 class RequiredIfSizedElement2(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
     
     def __init__(self, conditionalFieldName1, conditionalFieldName2, message=None, *args, **kwargs):
         self.conditionalFieldName1 = conditionalFieldName1
@@ -56,7 +56,7 @@ class RequiredIfSizedElement2(InputRequired):
             super(RequiredIfSizedElement2, self).__call__(form, field)
             
 class RequiredIfBitfieldFieldTypeForBit(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
 
     def __init__(self, conditionalFieldName, message=None, *args, **kwargs):
         self.conditionalFieldName = conditionalFieldName
@@ -70,7 +70,7 @@ class RequiredIfBitfieldFieldTypeForBit(InputRequired):
             super(RequiredIfBitfieldFieldTypeForBit, self).__call__(form, field)
             
 class RequiredIfBitfieldFieldTypeForBits(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
 
     def __init__(self, conditionalFieldName, message=None, *args, **kwargs):
         self.conditionalFieldName = conditionalFieldName
@@ -84,7 +84,7 @@ class RequiredIfBitfieldFieldTypeForBits(InputRequired):
             super(RequiredIfBitfieldFieldTypeForBits, self).__call__(form, field)
             
 class RequiredIfBitfieldFieldTypeForReference(InputRequired):
-    field_flags = ('requiredif',)
+    field_flags = {'requiredif': True}
 
     def __init__(self, conditionalFieldName, message=None, *args, **kwargs):
         self.conditionalFieldName = conditionalFieldName


### PR DESCRIPTION
Fix breaking changes in WTForms 3.2.1

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Tuple in wtforms.Flags are only supported till version WTForms 3.2.0. 
Changed `field_flags = ('requiredif',)` to `field_flags = {'requiredif': True}`

Link to the WTForms commit: https://github.com/pallets-eco/wtforms/commit/b7d54ab6307c3b74397ed8d81b9aa419da5ea553

## 💭 Motivation and context ##

With WTForms 3.2.1 opening the bitfields forms results in the error:
AttributeError: 'tuple' object has no attribute 'items'
