### PR TITLE
Add Time Type

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -33,7 +33,8 @@ spicyToZeek = {
     "string"    : "string",
     "enum"      : "string",
     "float"     : "double",
-    "bytes"     : "string"
+    "bytes"     : "string",
+    "time"      : "time"
 }
 customFieldTypes = {}
 
@@ -142,7 +143,17 @@ def _returnSpicyObjectType(itemType, enums, scope, referenceType, inputs):
                 outputString += ", "
         outputString += ")"
     return ("", outputString)
-    
+
+# function for converting to time type
+def _returnTimeType(size):
+    if size == 32:
+        return ("", "uint32 &convert=cast<time>($$)")
+    #elif size == 64:
+    #    return ("", "uint64 &convert=cast<time>($$)")
+    else:
+        print("Currently unknown time size {0}".format(size))
+        return ("", "")
+
 def _returnFloatType(size):
     if 32 == size:
         return ("", "real &type=spicy::RealType::IEEE754_Single")
@@ -236,6 +247,8 @@ def determineSpicyStringForType(itemName, itemType, elementType, referenceType, 
         return ("", "string")
     elif "switch" == itemType:
         return _returnSwitchType(scope, referenceType, inputs, customTypes, bitfields, switches, enums)
+    elif "time" == itemType: # added handler for time
+        return _returnTimeType(size)  # assumes 32-bit time in seconds    
     elif itemType in customTypes:
         # See if it's custom type
         sizeInBytes = int(ceil(size / 8))

--- a/backend/zeektypes.py
+++ b/backend/zeektypes.py
@@ -50,7 +50,7 @@ class ZeekMain:
         if pathName == "general":
             returnString += "{}$path=\"{}\",\n".format(indent, utils.PROTOCOL_NAME.lower())
         else:
-            returnString += "{}$path=\"{}_{}\",\n".format(utils.PROTOCOL_NAME.lower(), pathName)
+            returnString += "{}$path=\"{}_{}\",\n".format(indent, utils.PROTOCOL_NAME.lower(), pathName)
         #returnString += "{}$path=\"{}_{}\",\n".format(indent, utils.PROTOCOL_NAME.lower(), pathName)
         returnString += "{}$policy=log_policy_{}]);\n".format(indent, record.name.lower())
         return returnString

--- a/backend/zeektypes.py
+++ b/backend/zeektypes.py
@@ -46,7 +46,12 @@ class ZeekMain:
         returnString += "{}Log::create_stream({}::{},\n".format(indent, utils.PROTOCOL_NAME.upper(), recordLogName)
         returnString += "{}[$columns={}{},\n".format(indent, record.scope, record.name)
         returnString += "{}$ev=log_{},\n".format(indent, record.name.lower())
-        returnString += "{}$path=\"{}_{}\",\n".format(indent, utils.PROTOCOL_NAME.lower(), pathName)
+        # If the record is named "general", don't append the name to the path
+        if pathName == "general":
+            returnString += "{}$path=\"{}\",\n".format(indent, utils.PROTOCOL_NAME.lower())
+        else:
+            returnString += "{}$path=\"{}_{}\",\n".format(utils.PROTOCOL_NAME.lower(), pathName)
+        #returnString += "{}$path=\"{}_{}\",\n".format(indent, utils.PROTOCOL_NAME.lower(), pathName)
         returnString += "{}$policy=log_policy_{}]);\n".format(indent, record.name.lower())
         return returnString
         
@@ -192,7 +197,8 @@ class ZeekRecord:
         self.fields = []
         self.commandStructures = []
         self.column = 8
-        self.name = utils.commandNameToConst(name).lower() + "_log"
+        #self.name = utils.commandNameToConst(name).lower() + "_log" -> removed extra "_log" from output log filename
+        self.name = utils.commandNameToConst(name).lower()
 
         # self.subname = ""
         self.logName = ""

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -958,6 +958,7 @@ Parsnip supports:
     - only in bitfields
 * bytes
 * float values (float)
+* time
 * void
 
 ### Bytes
@@ -991,6 +992,22 @@ Parsnip Example:
     "size": 32
 }
 ```
+### Time Values
+
+Time values are used to represent timestamps passed in various protocol commands. Time fields will be parsed as an unsigned integer and converted to a timestamp for logging. Currently, Parsnip only supports 32 bit time fields.
+
+Parsnip Example:
+```JSON
+# Time Field
+
+{
+    "type": "time",
+    "description": "Description",
+    "name": "Name",
+    "size": 32
+}
+```
+
 
 ### Unsigned and Signed Integers
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Add a time type to Parsnip's valid types. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Several protocols pass timestamps related to various events. When these timestamps are logged as unsigned integers, it becomes more difficult for  log pipelines to properly interpret these values.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->
This was tested by added a timestamp field to My Simple Protocol IL files and ensuring the output of Parsnip is as expected. These changes were further tested with modified MySimpleProtocol PCAPs.
<img width="1043" height="668" alt="image" src="https://github.com/user-attachments/assets/34588e2e-2014-4a81-b093-b33c64be3de6" />
Spicy Time Field Output
<img width="865" height="472" alt="image" src="https://github.com/user-attachments/assets/77fc1c5e-73e5-4f68-a5fe-e82804ab0a81" />
Zeek Time Field Logging

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
